### PR TITLE
:art: Used classnames to make css properties smuder

### DIFF
--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -7,4 +7,4 @@ storiesOf("Button", module)
   .addDecorator(withInfo({ inline: true }))
   .add("Normal", () => <Button label={"Last opp"} />)
   .add("Disabled", () => <Button label={"Last opp"} disabled={true} />)
-  .add("Warning", () => <Button label={"Avbryt"} danger={true} />);
+  .add("Warning", () => <Button label={"Avbryt"} warning={true} />);

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -8,7 +8,7 @@ interface Props {
   /** Primary button styling */
   primary?: boolean;
   /** Danger button styling (red button) */
-  danger?: boolean;
+  warning?: boolean;
   /** Not clickable button */
   disabled?: boolean;
   /** Is it a submit button? */
@@ -18,34 +18,17 @@ interface Props {
 export const Button: FC<Props> = ({
   label,
   primary,
-  danger,
+  warning,
   disabled,
   submit,
   ...rest
-}: Props) => (
-  <button
-    className={`Button ${
-      danger ? `warning` : disabled ? `disabled` : `normal`
-    }`}
-  >
-    {label}
-  </button>
-);
+}: Props) => {
+  let buttonClass = cx({
+    Button,
+    warning,
+    disabled
+  });
+  return <button className={buttonClass}>{label}</button>;
+};
 
 export default Button;
-
-// return (
-//     <button
-//       className={
-//         flat
-//           ? cx(styles.flatButton, className)
-//           : cx(styles.button, styles[size], dark && styles.dark, className)
-//       }
-//       type={submit ? 'submit' : 'button'}
-//       {...rest}
-//     >
-//       <LoadingIndicator small margin={0} loading={pending} />
-//       {pending && <span className={styles.loading}>Laster</span>}
-//       {!pending && children}
-//     </button>
-//   );


### PR DESCRIPTION
Used classnames so that it is easier to make component look different depending on states. To read more about classnames. See link below.

[npm classnames](https://www.npmjs.com/package/classnames#usage-with-reactjs)

Also recommended by [React](https://reactjs.org/docs/faq-styling.html). See 

> Tip
[Research "classnames" npm package](https://app.gitkraken.com/glo/board/XZ4REar2-gAPzwhN/card/XaDE1i4hWwAQcvyJ)