### PR TITLE
:art: Changed button to use props.children

### DIFF
--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -5,8 +5,10 @@ import Button from "./Button";
 
 storiesOf("Button", module)
   .addDecorator(withInfo({ inline: true }))
-  .add("Normal", () => <Button label={"Last opp"} primary={true} />)
-  .add("Disabled", () => <Button label={"Last opp"} disabled={true} />)
+  .add("Normal", () => <Button primary={true}>Last opp</Button>)
+  .add("Disabled", () => <Button disabled={true}>Last opp</Button>)
   .add("Warning", () => (
-    <Button label={"Avbryt"} warning={true} onClick={() => alert("test")} />
+    <Button warning={true} onClick={() => alert("test")}>
+      Avbryt
+    </Button>
   ));

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -3,8 +3,8 @@ import cx from "classnames";
 import styles from "./Button.module.css";
 
 interface Props {
-  /** Button label */
-  label: string;
+  /** Content inside */
+  children?: any;
   /** Primary button styling */
   primary?: boolean;
   /** Danger button styling (red button) */
@@ -18,7 +18,7 @@ interface Props {
 }
 
 export const Button: FC<Props> = ({
-  label,
+  children,
   primary,
   warning,
   onClick,
@@ -45,7 +45,7 @@ export const Button: FC<Props> = ({
       disabled={disabled}
       {...rest}
     >
-      {label}
+      {children}
     </button>
   );
 };


### PR DESCRIPTION
Changed button from using label to props.children so that it is more reusable.
[Use props.children in GUI components](https://app.gitkraken.com/glo/board/XZ4REar2-gAPzwhN/card/XaNTXy4hWwAQcywS)